### PR TITLE
fix: DateComponent: Fixed 31st rollover bug.

### DIFF
--- a/projects/common/lib/components/date/date.component.ts
+++ b/projects/common/lib/components/date/date.component.ts
@@ -232,8 +232,11 @@ You must use either [restrictDate] or the [dateRange*] inputs.
       const day = this.getNumericValue(this._day);
       // console.log('CREATING DATE', { year, month, day });
 
+      // Date function appears to use setYear() so any year 0-99 results in year 1900 to 1999
+      // Set each field individually, use setFullYear() instead of setYear()
       // Set time on date to 00:00:00 for comparing later
       this.date = startOfDay(new Date(year, month, day));
+      this.date.setFullYear(year);
 
     } else {
       // Trigger validator for emptying fields use case. This is to remove the 'Invalid date' error.

--- a/projects/common/lib/components/date/date.component.ts
+++ b/projects/common/lib/components/date/date.component.ts
@@ -232,13 +232,8 @@ You must use either [restrictDate] or the [dateRange*] inputs.
       const day = this.getNumericValue(this._day);
       // console.log('CREATING DATE', { year, month, day });
 
-      // Date function appears to use setYear() so any year 0-99 results in year 1900 to 1999
-      // Set each field individually, use setFullYear() instead of setYear()
       // Set time on date to 00:00:00 for comparing later
-      this.date = startOfDay(new Date());
-      this.date.setMonth(month);
-      this.date.setFullYear(year); // To correct year when value has less than 4 characters
-      this.date.setDate(day);
+      this.date = startOfDay(new Date(year, month, day));
 
     } else {
       // Trigger validator for emptying fields use case. This is to remove the 'Invalid date' error.


### PR DESCRIPTION
The issue occurred on the 31st of the month, when setting the month to which doesn't have a 31st day. The `startOfDay(new Date())` would create a current date object (January 31st), and then set the month (ex: April with no 31st day), and the `setMonth` method would rollover to the next month (May dd, yyyy).