### PR TITLE
fix(HeaderComponent): Removed role attribute from header.

### DIFF
--- a/projects/common/lib/components/header/header.component.html
+++ b/projects/common/lib/components/header/header.component.html
@@ -10,7 +10,7 @@
              tabindex="-1" alt="B.C. Government Print Logo"
              src="{{printLogoSrc}}">
       </a>
-      <span class="title px-2 mt-1" role="banner">{{serviceName}}</span>
+      <span class="title px-2 mt-1">{{serviceName}}</span>
       <a [href]='skipLinkPath' class='skip-to-content'>Skip to main content</a>
     </div>
 <!--


### PR DESCRIPTION
Removed the `role="banner"` attribute as it's redundant for accessibility. This was causing accessibility validator to show as an error.

See example here: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Banner_role