### PR TITLE
fix: Fixed error container for phone number component

### DIFF
--- a/projects/common/lib/components/phone-number/phone-number.component.html
+++ b/projects/common/lib/components/phone-number/phone-number.component.html
@@ -16,7 +16,7 @@
 
 <!-- Error messages for component -->
 <common-error-container
-    [displayError]="!disabled && controlDir?.touched">
+    [displayError]="!disabled && controlDir?.touched && (controlDir?.errors?.required || controlDir?.errors?.incompleteValue)">
   <div *ngIf="controlDir?.errors?.required">
     {{_defaultErrMsg.required}}
   </div>

--- a/projects/common/lib/components/phone-number/phone-number.component.html
+++ b/projects/common/lib/components/phone-number/phone-number.component.html
@@ -16,7 +16,7 @@
 
 <!-- Error messages for component -->
 <common-error-container
-    [displayError]="!disabled && (controlDir?.touched || controlDir?.dirty) && (controlDir?.errors?.required || controlDir?.errors?.incompleteValue)">
+    [displayError]="!disabled && (controlDir?.touched || controlDir?.dirty) && controlDir?.errors">
   <div *ngIf="controlDir?.errors?.required">
     {{_defaultErrMsg.required}}
   </div>

--- a/projects/common/lib/components/phone-number/phone-number.component.html
+++ b/projects/common/lib/components/phone-number/phone-number.component.html
@@ -16,7 +16,7 @@
 
 <!-- Error messages for component -->
 <common-error-container
-    [displayError]="!disabled && controlDir?.touched && (controlDir?.errors?.required || controlDir?.errors?.incompleteValue)">
+    [displayError]="!disabled && (controlDir?.touched || controlDir?.dirty) && (controlDir?.errors?.required || controlDir?.errors?.incompleteValue)">
   <div *ngIf="controlDir?.errors?.required">
     {{_defaultErrMsg.required}}
   </div>


### PR DESCRIPTION
This was causing issues when scrolling to error upon continuing the form. It would scroll to this component first regardless of whether it had an error in it.