### PR TITLE
fix: Updated `ngx-bootstrap` dependencies to recommended imports.

### DIFF
--- a/projects/common/lib/components/address-validator/address-validator.component.spec.ts
+++ b/projects/common/lib/components/address-validator/address-validator.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed, getTestBed, fakeAsync, tick } from '@
 import { FormGroup, FormBuilder } from '@angular/forms';
 import { AddressValidatorComponent } from './address-validator.component';
 import { FormsModule } from '@angular/forms';
-import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap';
+import { TypeaheadModule, TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { of, throwError } from 'rxjs';

--- a/projects/common/lib/components/address-validator/address-validator.component.ts
+++ b/projects/common/lib/components/address-validator/address-validator.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input, ChangeDetectorRef, Output, EventEmitter, SimpleChanges, OnChanges, Optional, Self } from '@angular/core';
 import { Subject, Observable, of, throwError } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap, map, catchError } from 'rxjs/operators';
-import { TypeaheadMatch } from 'ngx-bootstrap';
+import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { HttpClient, HttpErrorResponse, HttpParams } from '@angular/common/http';
 import { NgControl, ControlValueAccessor } from '@angular/forms';
 import { Base } from '../../models/base';

--- a/projects/common/lib/components/address/address.component.spec.ts
+++ b/projects/common/lib/components/address/address.component.spec.ts
@@ -5,7 +5,7 @@ import { AddressComponent } from './address.component';
 import { FormsModule, NgForm } from '@angular/forms';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { TextMaskModule } from 'angular2-text-mask';
-import { TypeaheadModule } from 'ngx-bootstrap';
+import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 
 xdescribe('AddressComponent', () => {
   let component: AddressComponent;

--- a/projects/common/lib/components/consent-modal/consent-modal.component.spec.ts
+++ b/projects/common/lib/components/consent-modal/consent-modal.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import {FormsModule, NgForm} from '@angular/forms';
 import { ConsentModalComponent } from './consent-modal.component';
 
-import {ModalModule} from 'ngx-bootstrap';
+import {ModalModule} from 'ngx-bootstrap/modal';
 import {HttpClientModule} from '@angular/common/http';
 import {RouterTestingModule} from '@angular/router/testing';
 import { BrowserModule } from '@angular/platform-browser';

--- a/projects/common/lib/components/consent-modal/consent-modal.component.ts
+++ b/projects/common/lib/components/consent-modal/consent-modal.component.ts
@@ -1,5 +1,5 @@
 import { forwardRef, Component, EventEmitter, Input, Output, ViewChild, OnInit} from '@angular/core';
-import {ModalDirective} from 'ngx-bootstrap';
+import {ModalDirective} from 'ngx-bootstrap/modal';
 import { Observable, of } from 'rxjs';
 import { HttpClient, HttpHeaders, HttpErrorResponse } from '@angular/common/http';
 import { Response } from '@angular/http';

--- a/projects/common/lib/components/file-uploader/file-uploader.component.spec.ts
+++ b/projects/common/lib/components/file-uploader/file-uploader.component.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { FormsModule, ControlContainer, NgForm } from '@angular/forms';
 import { FileUploaderComponent } from './file-uploader.component';
 import {ThumbnailComponent} from '../thumbnail/thumbnail.component';
-import {ModalModule} from 'ngx-bootstrap';
+import {ModalModule} from 'ngx-bootstrap/modal';
 import { RouterTestingModule } from '@angular/router/testing';
 import * as moment from 'moment';
 import {HttpClientModule} from '@angular/common/http';

--- a/projects/common/lib/components/file-uploader/file-uploader.component.ts
+++ b/projects/common/lib/components/file-uploader/file-uploader.component.ts
@@ -3,7 +3,6 @@ import { AfterContentInit, ChangeDetectorRef, Component,
     OnInit, Output, SimpleChanges, ViewChild, forwardRef, AfterViewInit, ViewEncapsulation } from '@angular/core';
 import { NgForm, ControlContainer } from '@angular/forms';
 import * as moment from 'moment';
-import { ModalDirective} from 'ngx-bootstrap';
 import { PDFJSStatic } from 'pdfjs-dist';
 import { Observable ,  Observer, fromEvent, merge } from 'rxjs';
 import {map, filter, flatMap, scan, delay, retryWhen} from 'rxjs/operators';

--- a/projects/common/lib/components/geocoder-input/geocoder-input.component.spec.ts
+++ b/projects/common/lib/components/geocoder-input/geocoder-input.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core
 
 import { GeocoderInputComponent } from './geocoder-input.component';
 import { FormsModule } from '@angular/forms';
-import { TypeaheadModule } from 'ngx-bootstrap';
+import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
 import { GeocoderService } from '../../services/geocoder.service';

--- a/projects/common/lib/components/geocoder-input/geocoder-input.component.ts
+++ b/projects/common/lib/components/geocoder-input/geocoder-input.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, Input, ChangeDetectorRef, Output, EventEmitter, SimpleChanges, OnChanges, Optional, Self } from '@angular/core';
 import { Subject, Observable, of } from 'rxjs';
 import { debounceTime, distinctUntilChanged, switchMap, tap, catchError } from 'rxjs/operators';
-import { TypeaheadMatch } from 'ngx-bootstrap';
+import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { Base } from '../../models/base';
 import { GeocoderService, GeoAddressResult } from '../../services/geocoder.service';
 import { CANADA } from '../country/country.component';

--- a/projects/common/lib/components/sample-modal/sample-modal.component.ts
+++ b/projects/common/lib/components/sample-modal/sample-modal.component.ts
@@ -1,5 +1,5 @@
 import {Component, Input, ViewChild} from '@angular/core';
-import {ModalDirective} from 'ngx-bootstrap';
+import {ModalDirective} from 'ngx-bootstrap/modal';
 import { Base } from '../../models/base';
 
 export interface SampleImageInterface {

--- a/projects/common/lib/components/street/street.component.spec.ts
+++ b/projects/common/lib/components/street/street.component.spec.ts
@@ -1,5 +1,5 @@
 import { StreetComponent } from './street.component';
-import { TypeaheadModule } from 'ngx-bootstrap';
+import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ErrorContainerComponent } from '../error-container/error-container.component';
 import { Component, ViewChildren, QueryList, OnInit } from '@angular/core';

--- a/projects/common/lib/components/street/street.component.ts
+++ b/projects/common/lib/components/street/street.component.ts
@@ -3,7 +3,7 @@ import { NgControl } from '@angular/forms';
 import { Observable, Subject, of } from 'rxjs';
 import { GeoAddressResult, GeocoderService } from '../../services/geocoder.service';
 import { debounceTime, distinctUntilChanged, switchMap, catchError } from 'rxjs/operators';
-import { TypeaheadMatch } from 'ngx-bootstrap';
+import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 import { AbstractFormControl } from '../../models/abstract-form-control';
 import { ErrorMessage, LabelReplacementTag } from '../../models/error-message.interface';
 import { CANADA } from '../country/country.component';

--- a/projects/common/lib/components/thumbnail/thumbnail.component.spec.ts
+++ b/projects/common/lib/components/thumbnail/thumbnail.component.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { ThumbnailComponent } from './thumbnail.component';
-import {ModalModule} from 'ngx-bootstrap';
+import {ModalModule} from 'ngx-bootstrap/modal';
 
 describe('ThumbnailComponent', () => {
 

--- a/projects/common/lib/components/thumbnail/thumbnail.component.ts
+++ b/projects/common/lib/components/thumbnail/thumbnail.component.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild, OnInit, Input, Output, EventEmitter, ViewContainerRef, ViewEncapsulation } from '@angular/core';
-import { ModalDirective } from 'ngx-bootstrap';
+import { ModalDirective } from 'ngx-bootstrap/modal';
 
 import { CommonImage } from '../../models/images.model';
 

--- a/projects/common/lib/components/wizard-progress-bar/wizard-progress-bar.component.spec.ts
+++ b/projects/common/lib/components/wizard-progress-bar/wizard-progress-bar.component.spec.ts
@@ -1,7 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { WizardProgressBarComponent } from './wizard-progress-bar.component';
-import { AlertModule, ProgressbarModule } from 'ngx-bootstrap';
+import { AlertModule } from 'ngx-bootstrap/alert';
+import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
 import { RouterTestingModule } from '@angular/router/testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 

--- a/projects/common/lib/shared-core.module.ts
+++ b/projects/common/lib/shared-core.module.ts
@@ -6,7 +6,9 @@ import { PageFrameworkComponent } from './components/page-framework/page-framewo
 import { PasswordComponent } from './components/password/password.component';
 import { WizardProgressBarComponent } from './components/wizard-progress-bar/wizard-progress-bar.component';
 import { NgForm, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { ProgressbarModule, ModalModule, TypeaheadModule } from 'ngx-bootstrap';
+import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
+import { ModalModule } from 'ngx-bootstrap/modal';
+import { TypeaheadModule } from 'ngx-bootstrap/typeahead';
 import { RouterModule } from '@angular/router';
 import { DateComponent } from './components/date/date.component';
 import { DatepickerComponent } from './components/datepicker/datepicker.component';


### PR DESCRIPTION
Updating `ngx-bootstrap` dependencies to the recommended format as given on the documentation on their website: https://valor-software.com/ngx-bootstrap/#/alerts

This is also to resolve issues when importing the library into MSP, and using the latest component features (in `TypeaheadModule`).