### PR TITLE
style: DEMCL-22: prevent font inheritance

### DIFF
--- a/projects/common/captcha/src/captcha.component.scss
+++ b/projects/common/captcha/src/captcha.component.scss
@@ -173,7 +173,7 @@
     text-align: center;
     text-decoration: none;
     font-size: 10px; // changed from the default 18px
-    // default font-family removed
+    font-family: 'BCSans', 'Noto Sans', Verdana, Arial, sans-serif;
     font-weight: 700;
     letter-spacing: 1px;
     cursor: pointer;
@@ -237,7 +237,7 @@
     flex-direction: column;
     flex-flow: wrap;
     justify-content: space-between;
-    max-width: 303px;
+    max-width: 315px;
   }
 
   .defs {


### PR DESCRIPTION
Declaring font rather than inheriting as inheriting different fonts across different
projects (BCP, FPIncome, MSP) was varying the size of the component too much

Using standard font stack from devhub now
https://developer.gov.bc.ca/Design-System/Primary-Button#css