### PR TITLE
fix: DEA11Y-1: remove unneeded conflicting role

### DIFF
--- a/projects/common/lib/components/header/header.component.html
+++ b/projects/common/lib/components/header/header.component.html
@@ -1,4 +1,4 @@
-<header aria-label="Header">
+<header>
   <div class="container-fluid header-container d-flex justify-content-between align-items-center flex-wrap">
     <div class='d-flex flex-wrap'>
       <a href="http://www2.gov.bc.ca/" tabindex="0">


### PR DESCRIPTION
Tiny fix, this role was causing a banner role conflict. The default header tag role works