### PR TITLE
fix: DEA11Y-19: Remove tabindex from fileuploader icon

### DIFF
--- a/projects/common/lib/components/file-uploader/file-uploader.component.html
+++ b/projects/common/lib/components/file-uploader/file-uploader.component.html
@@ -1,7 +1,7 @@
 <div class="dropzone" #dropZone [ngClass]='{"has-error": fileControl?.touched && fileControl?.errors?.required}'>
 
   <div class="instruction-zone d-flex align-items-center flex-wrap flex-sm-nowrap flex-column flex-sm-row">
-    <i class="fa fa-cloud-upload fa-4x d-inline-block upload-icon" aria-hidden="true" #imagePlaceholderRef tabindex="0"></i>
+    <i class="fa fa-cloud-upload fa-4x d-inline-block upload-icon" aria-hidden="true" #imagePlaceholderRef></i>
 
     <input type="file" id="fileUploadBrowse-{{id}}"
             #browseFileRef ngModel accept="image/*,application/pdf" style="display:none;"


### PR DESCRIPTION
Prevent the accessibility issue of aria-hidden focusable elements. Removed the tab index as the other clickable text is already has a tabindex and is focusable