### PR TITLE
fix: DEA11Y-15: Made the Continue word darker

### DIFF
--- a/projects/common/lib/components/form-action-bar/form-action-bar.component.scss
+++ b/projects/common/lib/components/form-action-bar/form-action-bar.component.scss
@@ -48,3 +48,7 @@
     word-wrap: break-word;
 }
 
+.btn-secondary{
+    color: #000;
+}
+


### PR DESCRIPTION
Hi,

I would like to ask for your code review re: the minor fix on the text inside the Continue Button. I changed it to be darker when disabled.

![image](https://user-images.githubusercontent.com/47836606/96192770-9687e280-0efb-11eb-9fad-76f991d8a873.png)

Regards,
Cyril